### PR TITLE
FIX: namespacing of Barber class to prevent validator falling over

### DIFF
--- a/lib/plugin_guard/validator.rb
+++ b/lib/plugin_guard/validator.rb
@@ -32,8 +32,8 @@ class PluginGuard::Validator
         content = File.read(path)
 
         begin
-          Barber::Ember::Precompiler.new.compile(content)
-        rescue Barber::PrecompilerError => e
+          ::Barber::Ember::Precompiler.new.compile(content)
+        rescue ::Barber::PrecompilerError => e
           raise ValidatorError.new e.instance_variable_get(:@error)
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-plugin-guard
 # about: Guards your Discourse against plugin issues
-# version: 0.1.1
+# version: 0.1.2
 # authors: Angus McLeod
 # url: https://github.com/paviliondev/discourse-plugin-guard.git
 # contact_emails: development@pavilion.tech


### PR DESCRIPTION
* FIX: namespacing of Barber class to prevent validator
falling over and cron failing

See: https://discourse.pluginmanager.org/t/this-site-is-not-functioning-as-it-should/1037/5